### PR TITLE
Retrieve secret through function

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,17 @@ I haven't uploaded aide.el to any package repo yet (e.g., MELPA), so you have to
 Copy the content of `aide.el` to Emacs and evaluate it. 
 
 
+When using [straight.el](https://github.com/radian-software/straight.el), you can install aide.el as follows:
+
+```emacs-lisp
+(use-package aide
+  :straight (aide :type git
+                   :host github
+                   :repo "junjizhi/aide.el"))
+  :custom
+  (aide-openai-api-key-getter (lambda () "YOUR API KEY HERE"))
+```
+
 ## Usage
 
 Prerequisite: set `aide-openai-api-key-getter` to to retrieve your API key for OpenAI.
@@ -29,7 +40,7 @@ Then you can select any region and run `M-x aide-openai-completion-region-insert
 
 You can also run `M-x aide-openai-completion-buffer-insert`, which grabs the current buffer as a string, send it to OpenAI API and insert the result at the end of the buffer. This is like the [OpenAI playground](https://beta.openai.com/playground) where you can run the command multiple times to continue the conversion in the same buffer.
 
-  > Note: **This command reads th ENTIRE buffer**.
+  > Note: **This command reads the ENTIRE buffer**.
 
 ### Custom variables
 
@@ -42,6 +53,52 @@ Or you can set it directly in elisp:
 ``` emacs-lisp
 (setq aide-max-tokens 200)
 ```
+
+### Using password-store to retrieve your OpenAI key
+
+You can configure auth-source to use [password store](https://www.passwordstore.org/) as a backend by setting the `auth-sources` variable to contain `password-store` through:
+
+```emacs-lisp
+(customize-set-variable 'auth-sources '(password-store))
+```
+
+or by loading and configuration the *auth-source* package with straight:
+
+```emacs-lisp
+(use-package auth-source
+  :straight (:type built-in)
+
+  :config
+  (auth-source-pass-enable))
+```
+
+
+Eventually, you can then define the `aide-openai-api-key-getter` variable to retrieve the password from your password store:
+
+```emacs-lisp
+(customize-set-variable 'aide-openai-api-key-getter (lambda ()
+    (auth-source-pass-get 'secret "openai.com/user-handle/api-key")))
+```
+
+or again, when using straight:
+
+```emacs-lisp
+(use-package aide
+  :straight (aide :type git
+                   :host github
+                   :repo "junjizhi/aide.el"))
+  :custom
+  (aide-openai-api-key-getter (lambda ()
+    (auth-source-pass-get 'secret "openai.com/user-handle/api-key")))
+```
+
+#### Why would you want to use password store?
+
+Using password store, provides you a way to avoid having to store your API key in plaintext inside of your Emacs configuration that you may want to check into version control.
+
+Furthermore, your password store may enforce a mechanism to ensure that secrets become unavailable after a certain time, warranting another passphrase prompt if a key retrieval is attempted.
+
+All these benefit, you may get for free when using a password store.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -22,10 +22,8 @@ When using [straight.el](https://github.com/radian-software/straight.el), you ca
 ```emacs-lisp
 (use-package aide
   :straight (aide :type git
-                   :host github
-                   :repo "junjizhi/aide.el"))
-  :custom
-  (aide-openai-api-key-getter (lambda () "YOUR API KEY HERE"))
+                  :host github
+                  :repo "junjizhi/aide.el"))
 ```
 
 ## Usage
@@ -35,6 +33,8 @@ Prerequisite: set `aide-openai-api-key-getter` to to retrieve your API key for O
 ``` emacs-lisp
 (setq aide-openai-api-key-getter (lambda () "<api-key>"))
 ```
+
+> 💡 You can use any arbitrary means to retrieve your password, you can decrypt a local GPG file, access your favorite password-store or hardcode the secret directly in your config file.
 
 Then you can select any region and run `M-x aide-openai-completion-region-insert`.
 
@@ -56,13 +56,13 @@ Or you can set it directly in elisp:
 
 ### Using password-store to retrieve your OpenAI key
 
-You can configure auth-source to use [password store](https://www.passwordstore.org/) as a backend by setting the `auth-sources` variable to contain `password-store` through:
+You can configure auth-source to use [password store](https://www.passwordstore.org/) as a backend through the following function call:
 
 ```emacs-lisp
-(customize-set-variable 'auth-sources '(password-store))
+(auth-source-pass-enable)
 ```
 
-or by loading and configuration the *auth-source* package with straight:
+Straight.el users, can load and configuration the *auth-source* package as follows:
 
 ```emacs-lisp
 (use-package auth-source
@@ -73,10 +73,12 @@ or by loading and configuration the *auth-source* package with straight:
 ```
 
 
-Eventually, you can then define the `aide-openai-api-key-getter` variable to retrieve the password from your password store:
+Eventually, you can define the `aide-openai-api-key-getter` custom variable to retrieve the password from your password store:
 
 ```emacs-lisp
-(customize-set-variable 'aide-openai-api-key-getter (lambda ()
+(customize-set-variable
+  'aide-openai-api-key-getter
+  (lambda ()
     (auth-source-pass-get 'secret "openai.com/user-handle/api-key")))
 ```
 
@@ -85,11 +87,11 @@ or again, when using straight:
 ```emacs-lisp
 (use-package aide
   :straight (aide :type git
-                   :host github
-                   :repo "junjizhi/aide.el"))
+                  :host github
+                  :repo "junjizhi/aide.el")
   :custom
   (aide-openai-api-key-getter (lambda ()
-    (auth-source-pass-get 'secret "openai.com/user-handle/api-key")))
+                                (auth-source-pass-get 'secret "openai.com/user-handle/api-key"))))
 ```
 
 #### Why would you want to use password store?

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ Copy the content of `aide.el` to Emacs and evaluate it.
 
 ## Usage
 
-Prerequisite:
+Prerequisite: set `aide-openai-api-key-getter` to to retrieve your API key for OpenAI.
 
 ``` emacs-lisp
-(setq openai-api-key "<api-key>")
+(setq aide-openai-api-key-getter (lambda () "<api-key>"))
 ```
 
 Then you can select any region and run `M-x aide-openai-completion-region-insert`.

--- a/aide.el
+++ b/aide.el
@@ -65,6 +65,11 @@ the OpenAI API endpoint of this model."
   :group 'aide
   :options '("davinci", "text-davinci-002", "text-curie-001", "text-babbage-001", "text-ada-001"))
 
+(defcustom aide-openai-api-key-getter (lambda () "")
+  "Function that retrieves the valid OpenAI API key"
+  :type 'function
+  :group 'aide)
+
 (defun aide-openai-complete (api-key prompt)
   "Return the prompt answer from OpenAI API.
 API-KEY is the OpenAI API key.
@@ -173,7 +178,7 @@ INSTRUCTION and INPUT are the two params we send to the API."
 START and END are selected region boundaries."
   (interactive "r")
   (let* ((region (buffer-substring-no-properties start end))
-         (result (aide-openai-edits openai-api-key "Rephrase the text" region)))
+         (result (aide-openai-edits (funcall aide-openai-api-key-getter) "Rephrase the text" region)))
     (goto-char end)
     (if result
         (progn
@@ -192,7 +197,7 @@ START and END are selected region boundaries.
 The original content will be stored in the kill ring."
   (interactive "r")
   (let* ((region (buffer-substring-no-properties start end))
-         (result (aide-openai-edits openai-api-key "Rephrase the text" region)))
+         (result (aide-openai-edits (funcall aide-openai-api-key-getter) "Rephrase the text" region)))
     (goto-char end)
     (if result
         (progn
@@ -207,7 +212,7 @@ The original content will be stored in the kill ring."
 ;; private
 
 (defun aide--openai-complete-string (string)
-  (aide-openai-complete openai-api-key string))
+  (aide-openai-complete (funcall aide-openai-api-key-getter) string))
 
 (provide 'aide)
 ;;; aide.el ends here

--- a/aide.el
+++ b/aide.el
@@ -65,7 +65,7 @@ the OpenAI API endpoint of this model."
   :group 'aide
   :options '("davinci", "text-davinci-002", "text-curie-001", "text-babbage-001", "text-ada-001"))
 
-(defcustom aide-openai-api-key-getter (lambda () "")
+(defcustom aide-openai-api-key-getter (lambda () openai-api-key)
   "Function that retrieves the valid OpenAI API key"
   :type 'function
   :group 'aide)


### PR DESCRIPTION
After writing #5, I figured I had to do it anyways for private use since I'm quite aggressive about keeping secrets out of my config files.

For backwards compatibility's sake, I wrapped up my changes by defaulting to returning the `openai-api-key` variable so current users should be able to upgrade without things breaking. 😅 

Padded the readme a bit to provide installation examples for straight.el users and also 

Pls roast so I can improve this for merge.