### PR TITLE
Update for endpoint deprecation, rewrite complete buffer for chat.

### DIFF
--- a/aide.el
+++ b/aide.el
@@ -1,9 +1,9 @@
 ;;; aide.el --- An Emacs front end for GPT APIs like OpenAI  -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2021  Junji Zhi
+;; Copyright (C) 2021-2024 Junji Zhi and contributors
 
 ;; Author: Junji Zhi
-;; Keywords: gpt-3 openai
+;; Keywords: gpt-4 openai chatgpt
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -33,142 +33,58 @@
   :group 'external
   :prefix "aide-")
 
-(defcustom aide-ai-model "text-davinci-003"
-  "The model paramater that aide.el sends to all OpenAI API endpoints (except Chat API)."
-  :type 'string
-  :group 'aide)
-
 (defcustom aide-chat-model "gpt-3.5-turbo"
   "The model paramater that aide.el sends to OpenAI Chat API."
   :type 'string
   :group 'aide)
 
-
 (defcustom aide-max-input-tokens 3800
-  "The maximum number of tokens that aide.el sends to OpenAI API"
+  "The maximum number of tokens that aide.el sends to OpenAI API.
+Only affects the send COMPLETE buffer function."
   :type 'integer
   :group 'aide)
 
-(defcustom aide-max-output-tokens 100
-  "The max-tokens paramater that aide.el sends to OpenAI API."
-  :type 'integer
-  :group 'aide)
+;; Not currently utilized.
+;; (defcustom aide-max-output-tokens 100
+;;   "The max-tokens parameter that aide.el sends to OpenAI API."
+;;   :type 'integer
+;;   :group 'aide)
 
-(defcustom aide-temperature 0
-  "The temperature paramater that aide.el sends to OpenAI API."
-  :type 'float
-  :group 'aide)
+;; Not currently utilized.
+;; (defcustom aide-temperature 1
+;;   "The temperature paramater that aide.el sends to OpenAI API. 1 is default."
+;;   :type 'float
+;;   :group 'aide)
 
-(defcustom aide-top-p 0.1
-  "The top-p paramater that aide.el sends to OpenAI API."
-  :type 'float
-  :group 'aide)
+;; Not currently utilized.
+;; (defcustom aide-top-p 0.1
+;;   "The top-p parameter that aide.el sends to OpenAI API."
+;;   :type 'float
+;;   :group 'aide)
 
-(defcustom aide-frequency-penalty 0
-  "The frequency_penalty paramater that aide.el sends to OpenAI API."
-  :type 'float
-  :group 'aide)
+;; Not currently utilized.
+;; (defcustom aide-frequency-penalty 0
+;;   "The frequency_penalty parameter that aide.el sends to OpenAI API."
+;;   :type 'float
+;;   :group 'aide)
 
-(defcustom aide-presence-penalty 0
-  "The presence_penalty paramater that aide.el sends to OpenAI API."
-  :type 'float
-  :group 'aide)
-
-(defcustom aide-completions-model "davinci"
-  "Name of the model used for completions. aide sends requests to
-the OpenAI API endpoint of this model."
-  :type 'string
-  :group 'aide
-  :options '("davinci", "text-davinci-002", "text-curie-001", "text-babbage-001", "text-ada-001"))
+;; Not currently utilized.
+;; (defcustom aide-presence-penalty 0
+;;   "The presence_penalty parameter that aide.el sends to OpenAI API."
+;;   :type 'float
+;;   :group 'aide)
 
 (defcustom aide-openai-api-key-getter (lambda () openai-api-key)
   "Function that retrieves the valid OpenAI API key"
   :type 'function
   :group 'aide)
 
-(defun aide-openai-complete (api-key prompt)
-  "Return the prompt answer from OpenAI API.
-API-KEY is the OpenAI API key.
+(defcustom aide-save-chat-file "~/aide-log.txt"
+  "The location of the chat log; everything sent to and from OpenAI. Nil to disable."
+  :type 'function
+  :group 'aide)
 
-PROMPT is the prompt string we send to the API."
-  (let ((result nil)
-        (auth-value (format "Bearer %s" api-key)))
-    (request
-      "https://api.openai.com/v1/completions"
-      :type "POST"
-      :data (json-encode `(("prompt" . ,prompt)
-                           ("model"  . ,aide-ai-model)
-                           ("max_tokens" . ,aide-max-output-tokens)
-                           ("temperature" . ,aide-temperature)
-                           ("frequency_penalty" . ,aide-frequency-penalty)
-                           ("presence_penalty" . ,aide-presence-penalty)
-                           ("top_p" . ,aide-top-p)))
-      :headers `(("Authorization" . ,auth-value) ("Content-Type" . "application/json"))
-      :sync t
-      :parser 'json-read
-      :success (cl-function
-                (lambda (&key data &allow-other-keys)
-                  (setq result (alist-get 'text (elt (alist-get 'choices data) 0)))))
-      :error (cl-function (lambda (&rest args &key error-thrown &allow-other-keys)
-                 (message "Got error: %S" error-thrown))))
-      result))
-
-(defun aide-openai-chat (api-key prompt callback)
-  "Return the prompt answer from OpenAI API.
-API-KEY is the OpenAI API key.
-
-PROMPT is the prompt string we send to the API."
-  (let* ((result nil)
-        (auth-value (format "Bearer %s" api-key))
-        (payload (json-encode `(("model"  . ,aide-chat-model)
-                              ("messages" . [(("role" . "user") ("content" . ,prompt))])))))
-    (message "Waiting for OpenAI...")
-    (request
-      "https://api.openai.com/v1/chat/completions"
-      :type "POST"
-      :data payload
-      :headers `(("Authorization" . ,auth-value) ("Content-Type" . "application/json"))
-      :sync nil
-      :parser 'json-read
-      :success (cl-function
-                (lambda (&key data &allow-other-keys)
-                  (progn
-                    (setq result (alist-get 'content (alist-get 'message (elt (alist-get 'choices data) 0))))
-                    (funcall callback result)
-                    (message "Done."))))
-      :error (cl-function (lambda (&rest args &key error-thrown &allow-other-keys)
-                 (message "Got error: %S, payload: %S" error-thrown payload))))
-      result))
-
-
-(defun aide-openai-complete-region (start end)
-  "Send the region to OpenAI autocomplete engine and get the result.
-
-START and END are selected region boundaries."
-  (interactive "r")
-  (let* ((region (buffer-substring-no-properties start end))
-         (result (aide--openai-complete-string region)))
-    (message "%s" result)))
-
-(defun aide-openai-complete-region-insert (start end)
-  "Send the region to OpenAI and insert the result to the end of buffer.
-
-START and END are selected region boundaries."
-  (interactive "r")
-  (let* ((region (buffer-substring-no-properties start end))
-         (result (aide--openai-complete-string region))
-        original-point)
-    (goto-char (point-max))
-    (setq original-point (point))
-    (if result
-        (progn
-          (insert "\n" result)
-          (fill-paragraph)
-          (let ((x (make-overlay original-point (point-max))))
-            (overlay-put x 'face '(:foreground "orange red")))
-          result)
-      (message "Empty result"))))
-
+;; Functions for users to call
 (defun aide-openai-chat-region-insert (start end)
   "Send the region to OpenAI Chat API and insert the result to the end of buffer.
 
@@ -222,98 +138,106 @@ per line for text explanations and add line breaks if needed. Do not apply the c
       )
     (aide-openai-chat-region-insert region-start region-end)))
 
-
-(defun aide-openai-complete-buffer-insert ()
-  "Send the ENTIRE buffer, up to max tokens, to OpenAI and insert the result to the end of buffer."
+(defun aide-openai-chat-buffer-insert (&optional result)
+  "Send the ENTIRE buffer, up to max tokens, to OpenAI and insert the result to
+the end of buffer.
+Assumes the user is providing a prompt to ChatGPT somewhere in the enclosed text."
   (interactive)
-  (let (region
-        result
-        original-point)
-    (setq region (buffer-substring-no-properties (get-min-point) (point-max)))
-    (setq result (aide--openai-complete-string region))
-    (goto-char (point-max))
-    (setq original-point (point))
-    (if result
-        (progn
+  (if result
+      (progn
+        (let* ((original-point (point)))
+          (goto-char (point-max))
           (insert "\n" result)
           (fill-paragraph)
           (let ((x (make-overlay original-point (point-max))))
-            (overlay-put x 'face '(:foreground "orange red")))
-          result)
-      (message "Empty result"))))
+            (overlay-put x 'face '(:foreground "orange red")))))
+   (aide--openai-chat-string
+    (buffer-substring-no-properties (get-min-point) (point-max))
+    'aide-openai-chat-buffer-insert)))
 
-(defun aide-openai-tldr-region (start end)
-  "Send the region to OpenAI autocomplete engine and get the TLDR result.
+;; TODO rewrite to use chat with appropriate prompt. Complete endpoint gone in 1/2024
+;; (defun aide-openai-tldr-region (start end)
+;;   "Send the region to OpenAI autocomplete engine and get the TLDR result.
 
-START and END are selected region boundaries."
-  (interactive "r")
-  (let* ((region (buffer-substring-no-properties start end))
-         (result (aide--openai-complete-string (concat region "\n\n tl;dr:"))))
-    (message "%s" result)))
+;; START and END are selected region boundaries."
+;;   (interactive "r")
+;;   (let* ((region (buffer-substring-no-properties start end))
+;;          (result (aide--openai-complete-string (concat region "\n\n tl;dr:"))))
+;;     (message "%s" result)))
 
-(defun aide-openai-edits (api-key instruction input)
-  "Return the edits answer from OpenAI API.
+
+;; TODO rewrite to use chat with appropriate prompt. Complete endpoint gone in 1/2024
+;; (defun aide-openai-edits-region-insert (start end)
+;;    "Send the region to OpenAI edits and insert the result to the end of region.
+;; START and END are selected region boundaries."
+;;   (interactive "r")
+;;   (let* ((region (buffer-substring-no-properties start end))
+;;          (result (aide-openai-edits (funcall aide-openai-api-key-getter) "Rephrase the text" region)))
+;;     (goto-char end)
+;;     (if result
+;;         (progn
+;;           (insert "\n" result)
+;;           (fill-paragraph)
+;;           (let ((x (make-overlay end (point))))
+;;             (overlay-put x 'face '(:foreground "orange red")))
+;;           result)
+;;       (message "Empty result"))))
+
+;; TODO rewrite to use chat with appropriate prompt. Edit endpoint gone in 1/2024
+;; (defun aide-openai-edits-region-replace (start end)
+;;   "Send the region to OpenAI edits and replace the region.
+
+;; START and END are selected region boundaries.
+
+;; The original content will be stored in the kill ring."
+;;   (interactive "r")
+;;   (let* ((region (buffer-substring-no-properties start end))
+;;          (result (aide-openai-edits (funcall aide-openai-api-key-getter) "Rephrase the text" region)))
+;;     (goto-char end)
+;;     (if result
+;;         (progn
+;;           (kill-region start end)
+;;           (insert "\n" result)
+;;           (fill-paragraph)
+;;           (let ((x (make-overlay end (point))))
+;;             (overlay-put x 'face '(:foreground "orange red")))
+;;           result)
+;;       (message "Empty result"))))
+
+;; private; should not be called by users
+
+(defun aide-openai-chat (api-key prompt callback)
+  "Return the prompt answer from OpenAI API.
 API-KEY is the OpenAI API key.
 
-INSTRUCTION and INPUT are the two params we send to the API."
-  (let ((result nil)
-        (auth-value (format "Bearer %s" api-key)))
+PROMPT is the prompt string we send to the API."
+  (let* ((result nil)
+        (auth-value (format "Bearer %s" api-key)) 
+        (payload (json-encode `(("model"  . ,aide-chat-model)
+;                                ("max_tokens" . ,aide-max-output-tokens)
+;                                ("temperature" . ,aide-temperature)
+;                               ("frequency_penalty" . ,aide-frequency-penalty)
+;                                ("presence_penalty" . ,aide-presence-penalty)
+;                               ("top_p" . ,aide-top-p)))
+                                ("messages" . [(("role" . "user") ("content" . ,prompt))])))))
+    (message "Waiting for OpenAI...")
     (request
-      "https://api.openai.com/v1/engines/text-davinci-edit-001/edits"
+      "https://api.openai.com/v1/chat/completions"
       :type "POST"
-      :data (json-encode `(("input" . ,input)
-                           ("instruction" . ,instruction)
-                           ("temperature" . 0.9)))
-      :headers `(("Authorization" . ,auth-value)
-                 ("Content-Type" . "application/json"))
-      :sync t
+      :data payload
+      :headers `(("Authorization" . ,auth-value) ("Content-Type" . "application/json"))
+      :sync nil
       :parser 'json-read
       :success (cl-function
                 (lambda (&key data &allow-other-keys)
-                  (setq result (alist-get 'text (elt (alist-get 'choices data) 0))))))
-    result))
-
-(defun aide-openai-edits-region-insert (start end)
-  "Send the region to OpenAI edits and insert the result to the end of region.
-
-START and END are selected region boundaries."
-  (interactive "r")
-  (let* ((region (buffer-substring-no-properties start end))
-         (result (aide-openai-edits (funcall aide-openai-api-key-getter) "Rephrase the text" region)))
-    (goto-char end)
-    (if result
-        (progn
-          (insert "\n" result)
-          (fill-paragraph)
-          (let ((x (make-overlay end (point))))
-            (overlay-put x 'face '(:foreground "orange red")))
-          result)
-      (message "Empty result"))))
-
-(defun aide-openai-edits-region-replace (start end)
-  "Send the region to OpenAI edits and replace the region.
-
-START and END are selected region boundaries.
-
-The original content will be stored in the kill ring."
-  (interactive "r")
-  (let* ((region (buffer-substring-no-properties start end))
-         (result (aide-openai-edits (funcall aide-openai-api-key-getter) "Rephrase the text" region)))
-    (goto-char end)
-    (if result
-        (progn
-          (kill-region start end)
-          (insert "\n" result)
-          (fill-paragraph)
-          (let ((x (make-overlay end (point))))
-            (overlay-put x 'face '(:foreground "orange red")))
-          result)
-      (message "Empty result"))))
-
-;; private
-
-(defun aide--openai-complete-string (string)
-  (aide-openai-complete (funcall aide-openai-api-key-getter) string))
+                  (progn
+                    (setq result (alist-get 'content (alist-get 'message (elt (alist-get 'choices data) 0))))
+                    (log-call-response prompt result)
+                    (funcall callback result)
+                    (message "Done."))))
+      :error (cl-function (lambda (&rest args &key error-thrown &allow-other-keys)
+                 (message "Got error: %S, payload: %S" error-thrown payload))))
+      result))
 
 (defun aide--openai-chat-string (string callback)
   (aide-openai-chat (funcall aide-openai-api-key-getter) string callback))
@@ -324,6 +248,13 @@ maxes out at request of 4000 tokens; ~15200 char"
   (if (> (buffer-size) (* 4 (or aide-max-input-tokens 3800))) ;; 1 tokens = ~4 char
       (- (point-max) (* 4 (or aide-max-input-tokens 3800)))
     (point-min)))
+
+(defun log-call-response (prompt response)
+  (if aide-save-chat-file
+      (write-region
+      ; Starting with * allows users to view log w/ org mode for easy folding
+       (concat "*" (current-time-string) "\n" prompt "\n" response)
+       nil aide-save-chat-file 'append)))
 
 (provide 'aide)
 ;;; aide.el ends here


### PR DESCRIPTION
Also add logging to aid in debugging prompts, if needed. Calling the API is not free.

--
Hi @junjizhi I just got back to this code recently for the first time in a year; thank you for updating it for the new chat endpoints. I commented out some code that will soon stop working due to API changes, and rewrote how the `defun aide-openai-chat-buffer-insert` function works so that it's possible to send the entire buffer to the new chat endpoints and utilize the new models with larger context.

I hope you find this useful; I thought it would be better to comment out functions that will soon break (January 2024) rather than having users try to utilize them and being disappointed. I'm sure the functions can be rewritten for use with the new Chat endpoints, but that's beyond my prompt engineering skills at the moment. 

Thanks again for creating this in the first place, very useful!
Best,
Nick